### PR TITLE
Rewrite print with abstract and glimpse

### DIFF
--- a/R/datasets.R
+++ b/R/datasets.R
@@ -57,9 +57,11 @@ qa_dataset <- function(name, cache_directory = qa_cache_dir(), refresh_cache = 0
 print.qa_dataset <- function(x, ...) {
     ## as a placeholder, we'll just print the dataset object as a data.frame, but hide the bb_source component
     temp <- x
-    temp$bb_source <- NULL
+    message("This Quantarctica dataset is made available under a ",temp$bb_source$license," license.\n")
+    message("If the abstract provides a specific citation for this dataset, please use the citation in the abstract: \n",temp$abstract,"\n\n" )
+    message("Otherwise cite as: ", temp$bb_source$citation)
     class(temp) <- setdiff(class(temp), "qa_dataset")
-    print(temp)
+    dplyr::glimpse(temp)
 }
 
 #' Available Quantarctica data sets

--- a/R/datasets.R
+++ b/R/datasets.R
@@ -57,11 +57,11 @@ qa_dataset <- function(name, cache_directory = qa_cache_dir(), refresh_cache = 0
 print.qa_dataset <- function(x, ...) {
     ## as a placeholder, we'll just print the dataset object as a data.frame, but hide the bb_source component
     temp <- x
-    message("This Quantarctica dataset is made available under a ",temp$bb_source$license," license.\n")
-    message("If the abstract provides a specific citation for this dataset, please use the citation in the abstract: \n",temp$abstract,"\n\n" )
+    message("This Quantarctica dataset is made available under a ", temp$bb_source$license, " license.\n")
+    message("If the abstract provides a specific citation for this dataset, please use the citation in the abstract: \n", temp$abstract, "\n\n" )
     message("Otherwise cite as: ", temp$bb_source$citation)
     class(temp) <- setdiff(class(temp), "qa_dataset")
-    dplyr::glimpse(temp)
+    tibble::glimpse(temp)
 }
 
 #' Available Quantarctica data sets

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,5 +1,5 @@
 .onAttach <- function(libname, pkgname) {
-    packageStartupMessage("Quantarctica is made available under a CC-BY license. If you use it, please cite it:\nMatsuoka K, Skoglund A, Roth G (2018) Quantarctica [Data set]. Norwegian Polar Institute. https://doi.org/10.21334/npolar.2018.8516e961\nIn addition, published works produced using Quantarctica are asked to cite each dataset that was used in the work. Please consult the abstract of each data set for the relevant citation.\n\nQuantarcticR is using a temporary data directory for this session: see the `qa_cache_dir` function to change this.")
+    packageStartupMessage("Quantarctica is made available under a CC-BY license. If you use it, please cite it:\nMatsuoka K, Skoglund A, Roth G (2018) Quantarctica 3. Norwegian Polar Institute. https://doi.org/10.21334/npolar.2018.8516e961\nIn addition, published works produced using Quantarctica are asked to cite each dataset that was used in the work. Please consult the abstract of each data set for the relevant citation.\n\nQuantarcticR is using a temporary data directory for this session: see the `qa_cache_dir` function to change this.")
 }
 
 

--- a/man/quantarcticR-package.Rd
+++ b/man/quantarcticR-package.Rd
@@ -16,6 +16,7 @@ Authors:
   \item Kim Fitter \email{kim@validly.co}
   \item Charlène Guillaumot
   \item David Ranzolin \email{daranzolin@gmail.com}
+  \item Marc Desgroseilliers
 }
 
 }


### PR DESCRIPTION
The print now includes the abstract text from the dataset and `glimpse`.
As a suggestion I have not excluded bb_source like previous version. With `glimpse` you can include all the variables as a user friendly output.